### PR TITLE
Prepare release of 2.5

### DIFF
--- a/946.patch
+++ b/946.patch
@@ -1,0 +1,23 @@
+From 129588442041c32b0d98f2361a69e0e350592f70 Mon Sep 17 00:00:00 2001
+From: Oskar Kruschitz <okr@huemer-it.com>
+Date: Thu, 13 Dec 2018 16:13:01 +0100
+Subject: [PATCH] Added missing Include
+
+Fixing an error during Build with Qt5.12:
+error: member access into incomplete type 'const QWebEngineCertificateError'
+---
+ src/gui/wizard/webview.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/gui/wizard/webview.cpp b/src/gui/wizard/webview.cpp
+index 15c1f314e..73e671b8f 100644
+--- a/src/gui/wizard/webview.cpp
++++ b/src/gui/wizard/webview.cpp
+@@ -10,6 +10,7 @@
+ #include <QProgressBar>
+ #include <QLoggingCategory>
+ #include <QLocale>
++#include <QWebEngineCertificateError>
+ 
+ #include "common/utility.h"
+ 

--- a/org.nextcloud.Nextcloud.json
+++ b/org.nextcloud.Nextcloud.json
@@ -54,20 +54,26 @@
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DNO_SHIBBOLETH=1",
                 "-DCMAKE_INSTALL_LIBDIR=/app/lib",
-                "-DLIB_INSTALL_DIR=/app/lib"
+                "-DLIB_INSTALL_DIR=/app/lib",
+                "-DBUILD_SHELL_INTEGRATION_DOLPHIN=0",
+                "-DBUILD_SHELL_INTEGRATION_NAUTILUS=0"
             ],
             "build-commands": [
                 "install -m755 nextcloud-client /app/bin"
             ],
             "post-install": [
                 "mkdir -p /app/share/appdata",
-                "cp ../org.nextcloud.Nextcloud.appdata.xml /app/share/appdata"
+                "cp org.nextcloud.Nextcloud.appdata.xml /app/share/appdata"
             ],
             "sources": [
                 {
                     "type": "git", 
                     "url": "https://github.com/nextcloud/desktop.git",
-                    "branch": "master"
+                    "tag": "v2.5.1"
+                },
+                {
+                    "type": "patch",
+                    "path": "946.patch"
                 },
                 {
                     "type": "script",

--- a/org.nextcloud.Nextcloud.json
+++ b/org.nextcloud.Nextcloud.json
@@ -2,7 +2,7 @@
     "app-id": "org.nextcloud.Nextcloud",
     "branch": "stable",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.9",
+    "runtime-version": "5.12",
     "sdk": "org.kde.Sdk",
     "command": "nextcloud-client",
     "rename-desktop-file": "nextcloud.desktop",
@@ -52,14 +52,12 @@
             "buildsystem": "cmake",
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
-                "-DOEM_THEME_DIR=/run/build/nextcloud-client/nextcloudtheme",
                 "-DNO_SHIBBOLETH=1",
                 "-DCMAKE_INSTALL_LIBDIR=/app/lib",
                 "-DLIB_INSTALL_DIR=/app/lib"
             ],
-            "subdir": "client",
             "build-commands": [
-                "install -m755 ../nextcloud-client /app/bin"
+                "install -m755 nextcloud-client /app/bin"
             ],
             "post-install": [
                 "mkdir -p /app/share/appdata",
@@ -68,13 +66,13 @@
             "sources": [
                 {
                     "type": "git", 
-                    "url": "https://github.com/nextcloud/client_theming.git",
-                    "tag": "v2.3.3"
+                    "url": "https://github.com/nextcloud/desktop.git",
+                    "branch": "master"
                 },
                 {
                     "type": "script",
                     "dest-filename": "nextcloud-client",
-                    "commands": ["exec env TMPDIR=$XDG_CACHE_HOME /app/bin/nextcloud \"$@\""]
+                    "commands": ["exec env TMPDIR=/var/tmp /app/bin/nextcloud \"$@\""]
                 },
                 {
                     "type": "file",


### PR DESCRIPTION
ToDo:

- [x] Update version to tag
- [x] Exclude dolphin plugin build
```
-- Installing: /app/lib/libnextclouddolphinpluginhelper.so
CMake Error at shell_integration/dolphin/cmake_install.cmake:82 (file):
  file cannot create directory: /usr/lib/plugins/kf5/overlayicon.  Maybe need
  administrative privileges.
Call Stack (most recent call first):
  shell_integration/cmake_install.cmake:44 (include)
  cmake_install.cmake:59 (include)
```

Waiting for:
- [x] ~2.5.2~ applied the patch manually https://github.com/nextcloud/desktop/pull/946