### PR TITLE
Use default-branch instead of branch

### DIFF
--- a/org.nextcloud.Nextcloud.json
+++ b/org.nextcloud.Nextcloud.json
@@ -1,13 +1,13 @@
 {
     "app-id": "org.nextcloud.Nextcloud",
-    "branch": "stable",
+    "default-branch": "stable",
     "runtime": "org.kde.Platform",
     "runtime-version": "5.12",
     "sdk": "org.kde.Sdk",
     "command": "nextcloud-client",
     "rename-desktop-file": "nextcloud.desktop",
     "rename-icon": "Nextcloud",
-    "copy-icon": true,	
+    "copy-icon": true,
     "finish-args": [
         "--socket=x11",
         "--share=network",
@@ -44,7 +44,7 @@
             ],
             "sources": [
                 {
-                    "type": "archive", 
+                    "type": "archive",
                     "url": "https://github.com/frankosterfeld/qtkeychain/archive/v0.9.0.tar.gz",
                     "sha256": "0935e5eb67fbed0b2db5e74ea8cbd667c6be6eed3767f212eac6ac318ab8a6fc"
                 }
@@ -70,7 +70,7 @@
             ],
             "sources": [
                 {
-                    "type": "git", 
+                    "type": "git",
                     "url": "https://github.com/nextcloud/desktop.git",
                     "tag": "v2.5.1"
                 },
@@ -89,5 +89,5 @@
                 }
             ]
         }
-    ] 
+    ]
 }


### PR DESCRIPTION
This way buildbot sets the branch name to beta or stable depending on the git branch.
Once this is merged i would like to rebase the beta branch onto master to keep the difference minimal.

Closes #30 
