### PR TITLE
Use one TMPDIR for all instances

### DIFF
--- a/org.nextcloud.Nextcloud.json
+++ b/org.nextcloud.Nextcloud.json
@@ -17,7 +17,8 @@
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.kde.StatusNotifierWatcher",
-        "--env=LD_LIBRARY_PATH=/app/lib:/app/lib/nextcloud"
+        "--env=LD_LIBRARY_PATH=/app/lib:/app/lib/nextcloud",
+        "--env=TMPDIR=/var/tmp"
     ],
     "cleanup": [
         "/share/icons/hicolor/1024x1024"


### PR DESCRIPTION
According to #10, Nextcloud does indeed react to this change, so there is no reason not to include this.