### PR TITLE
Allow Nextcloud to own org.kde.*

### DIFF
--- a/org.nextcloud.Nextcloud.yml
+++ b/org.nextcloud.Nextcloud.yml
@@ -21,6 +21,7 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.kde.StatusNotifierWatcher
+  - --own-name=org.kde.*
   - --env=LD_LIBRARY_PATH=/app/lib:/app/lib/nextcloud
   - --env=TMPDIR=/var/tmp
 


### PR DESCRIPTION
To show an Ubuntu-style App Indicator, Qt tries to own a name of the
form org.kde.StatusNotifierItem-$PID-1. In practice, with Nextcloud on
my Endless OS system, this is currently always
org.kde.StatusNotifierItem-3-1; but in general there's no guarantee what
the application's PID will be within the sandbox.

Allowing Nextcloud to own names in this namespace fixes the tray icon,
with the caveat that many Flatpak:ed apps end up with PID 3 in their own
namespace, so only one of them will be able to show a tray icon. (For
example, I use the Vorta backup application, which tries to own the same
name.)

This could be fixed by fixing Qt to disambiguate using the D-Bus unique
name (which is globally unique). Ideally the specification would also be
changed to not require owning an entire namespace of names. In the
meantime, this change will allow the tray icon to work in some cases.

(There is no security implication to this change because the app has
read-write access to the entire host filesystem.)

Fixes #62